### PR TITLE
add missing interface files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "dist/index.js.map",
     "dist/index.d.ts",
     "dist/index.d.ts.map",
+    "dist/interfaces.js",
+    "dist/interfaces.js.map",
+    "dist/interfaces.d.ts",
+    "dist/interfaces.d.ts.map",
     "package.json",
     "LICENSE",
     "README"


### PR DESCRIPTION
Currently using this package in a typescript project, produces the following error:

![Screenshot 2021-07-27 at 11 00 45](https://user-images.githubusercontent.com/935782/127135598-982a9f64-0559-48de-aca9-203854ce5e07.png)

It appears the compiled interfaces files are not being included when this package is published to npm. Including the relevant file names under the 'files' attribute in package.json should resolve the issue.
